### PR TITLE
adds test for log_space_multinomial_sampler

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ ep <- function(intercepts, coefficients, latent_positions, sender, recipient, cu
     .Call('CCAS_ep', PACKAGE = 'CCAS', intercepts, coefficients, latent_positions, sender, recipient, current_covariates, interaction_pattern, using_coefficients)
 }
 
-lsms <- function(unnormalized_discrete_distribution, seed) {
-    .Call('CCAS_lsms', PACKAGE = 'CCAS', unnormalized_discrete_distribution, seed)
+lsms <- function(unnormalized_discrete_distribution, seed, u = NA_real_) {
+    .Call('CCAS_lsms', PACKAGE = 'CCAS', unnormalized_discrete_distribution, seed, u)
 }
 
 sotep <- function(edge_probabilities, tokens_in_document, current_token_topic_assignment, current_document_topic_counts, leave_out_current_token, topic_interaction_patterns, document_sender, document_recipient, leave_out_topic) {

--- a/R/test_internal_functions.R
+++ b/R/test_internal_functions.R
@@ -145,6 +145,7 @@
 #' @param use_cached_token_topic_distribution A boolean.
 #' @param cached_token_topic_distribution A vector with legth equal to the number
 #' of topics.
+#' @param u A numeric of length 1 between 0 and 1.
 #' @return Whatever is returned by the internal function being tested
 #' @export
 test_internal_functions <- function(
@@ -220,14 +221,15 @@ test_internal_functions <- function(
     slice_sample_step_size = NULL,
     parallel = NULL,
     use_cached_token_topic_distribution = NULL,
-    cached_token_topic_distribution = NULL){
+    cached_token_topic_distribution = NULL,
+    u = NULL) {
 
     return_object <- NULL
 
     # test the lsms function
     if (Test_Log_Space_Multinomial_Sampler) {
         return_object <- lsms(distribution,
-                              seed)
+                              seed, u)
     }
 
     # test ep function

--- a/man/ccas.Rd
+++ b/man/ccas.Rd
@@ -7,7 +7,7 @@
 ccas(formula, interaction_patterns = 4, topics = 40, alpha = 1,
   beta = 0.01, iterations = 1000, metropolis_hastings_iterations = 500,
   final_metropolis_hastings_burnin = 50000,
-  final_metropolis_hastings_iterations = 1e+05, thin = 1/100,
+  final_metropolis_hastings_iterations = 100000, thin = 1/100,
   target_accept_rate = 0.25, tolerance = 0.05,
   LSM_proposal_variance = 0.5, LSM_prior_variance = 1, LSM_prior_mean = 0,
   iterations_before_t_i_p_updates = 5, update_t_i_p_every_x_iterations = 5,

--- a/man/test_internal_functions.Rd
+++ b/man/test_internal_functions.Rd
@@ -45,7 +45,7 @@ test_internal_functions(Test_Log_Space_Multinomial_Sampler = FALSE,
   perform_adaptive_metropolis = NULL, resample_word_types = NULL,
   slice_sample_alpha_m = NULL, slice_sample_step_size = NULL,
   parallel = NULL, use_cached_token_topic_distribution = NULL,
-  cached_token_topic_distribution = NULL)
+  cached_token_topic_distribution = NULL, u = NULL)
 }
 \arguments{
 \item{Test_Log_Space_Multinomial_Sampler}{Defualts to FALSE. If TRUE, then
@@ -264,6 +264,8 @@ the value directly (normally 5, set to a negative number to turn off)),}
 
 \item{cached_token_topic_distribution}{A vector with legth equal to the number
 of topics.}
+
+\item{u}{A numeric of length 1 between 0 and 1.}
 }
 \value{
 Whatever is returned by the internal function being tested

--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -2213,8 +2213,7 @@ double ep(arma::vec intercepts,
 }
 
 // [[Rcpp::export]]
-int lsms(arma::vec unnormalized_discrete_distribution,
-         int seed){
+int lsms(arma::vec unnormalized_discrete_distribution, int seed, double u=NA_REAL){
 
     // Set RNG and define uniform distribution
     boost::mt19937 generator(seed);
@@ -2222,6 +2221,10 @@ int lsms(arma::vec unnormalized_discrete_distribution,
 
     // get the random uniform draw
     double rand_num = uniform_distribution(generator);
+
+    if (arma::is_finite(u)) {
+      rand_num = u;
+    }
 
     // take a draw from the unnormalized log distribution
     int temp = mjd::log_space_multinomial_sampler (

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -25,14 +25,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // lsms
-int lsms(arma::vec unnormalized_discrete_distribution, int seed);
-RcppExport SEXP CCAS_lsms(SEXP unnormalized_discrete_distributionSEXP, SEXP seedSEXP) {
+int lsms(arma::vec unnormalized_discrete_distribution, int seed, double u);
+RcppExport SEXP CCAS_lsms(SEXP unnormalized_discrete_distributionSEXP, SEXP seedSEXP, SEXP uSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< arma::vec >::type unnormalized_discrete_distribution(unnormalized_discrete_distributionSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    __result = Rcpp::wrap(lsms(unnormalized_discrete_distribution, seed));
+    Rcpp::traits::input_parameter< double >::type u(uSEXP);
+    __result = Rcpp::wrap(lsms(unnormalized_discrete_distribution, seed, u));
     return __result;
 END_RCPP
 }

--- a/tests/testthat/test_log_space_multinomial_sampler.R
+++ b/tests/testthat/test_log_space_multinomial_sampler.R
@@ -5,13 +5,20 @@ test_that("Log space multinomial sampler works", {
     set.seed(12345)
     # have to assign variables to the global environment so they will run in
     # automatic tests
-    dist <- round(runif(100, min = -500, max = -400))
+
+    k <- 100
+    dist <- runif(k)
+    u <- runif(1)
+    bins <- cut(dist, k)
+    uppers <- as.numeric(sub("[^,]*,([^]]*)\\]", "\\1", levels(bins)))
+    j <- findInterval(u, uppers, all.inside = TRUE)
+
     seed <- 123456
     # get the result
     result <- test_internal_functions(
         Test_Log_Space_Multinomial_Sampler = TRUE,
-        distribution = dist,
-        seed = seed)
+        distribution = log(dist), seed = seed, u = u)
 
+    expect_that(j, equals(result))
 })
 


### PR DESCRIPTION
adds an argument `u` to `lsms` which is ignored if its default argument is unchanged, but substitutes it in place of the uniform draw it would normally generate from `arma` if it is modified, which allows us to do an exact unit test.
